### PR TITLE
Some portability fixes to allow building on Linux

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -9,6 +9,9 @@
 #define PALETTE_RGB565 1
 #define PALETTE_RGB5A3 2
 
+inline int max(int, int);
+inline int min(int, int);
+
 void btiDecodeI4(uint8_t* dst, uint8_t* src, uint16_t width, uint16_t height) {
     if (src == NULL || dst == NULL)
         return;
@@ -535,4 +538,11 @@ void btiDecodeCMPR(uint8_t* dst, uint8_t* src, uint16_t width, uint16_t height) 
             }
         }
     }
+}
+
+inline int max(int x, int y){
+    return x < y ? y : x;
+}
+inline int min(int x, int y){
+    return x < y ? x : y;
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -9,12 +9,14 @@
 #define PALETTE_RGB565 1
 #define PALETTE_RGB5A3 2
 
+#if defined(__linux__)
 inline int max(int x, int y){
     return x < y ? y : x;
 }
 inline int min(int x, int y){
     return x < y ? x : y;
 }
+#endif
 void btiDecodeI4(uint8_t* dst, uint8_t* src, uint16_t width, uint16_t height) {
     if (src == NULL || dst == NULL)
         return;

--- a/src/decode.c
+++ b/src/decode.c
@@ -9,9 +9,12 @@
 #define PALETTE_RGB565 1
 #define PALETTE_RGB5A3 2
 
-inline int max(int, int);
-inline int min(int, int);
-
+inline int max(int x, int y){
+    return x < y ? y : x;
+}
+inline int min(int x, int y){
+    return x < y ? x : y;
+}
 void btiDecodeI4(uint8_t* dst, uint8_t* src, uint16_t width, uint16_t height) {
     if (src == NULL || dst == NULL)
         return;
@@ -538,11 +541,4 @@ void btiDecodeCMPR(uint8_t* dst, uint8_t* src, uint16_t width, uint16_t height) 
             }
         }
     }
-}
-
-inline int max(int x, int y){
-    return x < y ? y : x;
-}
-inline int min(int x, int y){
-    return x < y ? x : y;
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,5 +1,6 @@
 #include "decode.h"
 #include <stdlib.h>
+#include <string.h>
 
 #define BytesToShort(a, b) (a << 8 | b)
 #define BytesToInt(a, b, c, d) (a << 24 | b << 16 | c << 8 | d)


### PR DESCRIPTION
This fixes two things that are preventing a Linux build: string.h isn't included in one of the places where memcpy is used, and the min and max functions from a windows header are used. It shouldn't change any functionality besides getting it to build and work on Linux.